### PR TITLE
Clean up Docker image build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 services:
   - docker
+env:
+  global:
+    DOCKER_IMAGE_TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "$TRAVIS_BRANCH" ; fi)
+    DOCKER_IMAGE_NAME="sifive/environment-blockci"
 
-script:
-  - docker login -u $USERNAME -p $PASSWORD
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - docker build --file=environment-blockci.Dockerfile --tag=sifive/environment-blockci:$TAG .
-  - if [ "$TRAVIS_TAG" != "" ]; then docker push sifive/environment-blockci; fi
+stages:
+  - test
+  - deploy
+
+jobs:
+  include:
+    - stage: test
+      name: "Build Wit Dockerfile"
+      script: ./build_image.sh
+
+    - stage: deploy
+      name: "Deploy Docker Image"
+      # For pull requests, branch is the base branch (on PR to master: branch = master)
+      if: tag IS present OR (branch = master AND type = push)
+      script:
+        - ./build_image.sh
+        - ./push_image.sh

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+docker build --file=environment-blockci.Dockerfile --tag="$DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG" .

--- a/environment-blockci.Dockerfile
+++ b/environment-blockci.Dockerfile
@@ -1,29 +1,29 @@
 FROM ubuntu:xenial 
 
 RUN apt-get update && apt-get install -y \
-  wget \
-  zip \
+  autoconf \
+  autotools-dev \
   curl \
-  openjdk-8-jdk \
-  software-properties-common \
   device-tree-compiler \
-  libfdt-dev \
-  libre2-dev \
-  nodejs \
-  python3-pip \
-  makedev \
   fuse \
-  libfuse-dev \
-  libsqlite3-dev \
-  libgmp-dev \
-  libncurses5-dev \
-  pkg-config \
-  git \
   g++ \
   gcc \
+  git \
+  libfdt-dev \
+  libfuse-dev \
+  libgmp-dev \
+  libncurses5-dev \
+  libre2-dev \
+  libsqlite3-dev \
   libtool-bin \
-  autoconf \
-  autotools-dev 
+  makedev \
+  nodejs \
+  openjdk-8-jdk \
+  pkg-config \
+  python3-pip \
+  software-properties-common \
+  wget \
+  zip
 
 RUN wget https://github.com/sifive/wake/releases/download/v0.15.1/ubuntu-16.04-wake_0.15.1-1_amd64.deb && \
     dpkg -i ubuntu-16.04-wake_0.15.1-1_amd64.deb

--- a/push_image.sh
+++ b/push_image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+docker push "$DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG"


### PR DESCRIPTION
This basically just copies and pastes the Docker image building script and strategy that we're using in https://github.com/sifive/wit. I haven't tested the actual image deploy step, but I can do a dummy test by temporarily creating a tag off this PR and seeing if it works.

I also added a completely unrelated commit to sort the list of apt packages in the Dockerfile, since I think it helps with readability. I am totally fine with leaving that change out if you prefer.