### PR TITLE
Bumped wake from 0.15.1 to 0.17.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Backwards Incompatible Changes
+- Bumped version of wake from 0.15.1 to 0.17.1, which contains backwards incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.16.0 and https://github.com/sifive/wake/releases/tag/v0.17.0 for the major changes.
+
+[Unreleased]: https://github.com/sifive/environment-blockci-sifive/compare/0.2.1...HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -L -o /tmp/verilator.deb -L https://github.com/sifive/verilator/release
   rm /tmp/verilator.deb
 
 # Install Wake into /usr
-RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.15.1/ubuntu-16.04-wake_0.15.1-1_amd64.deb && \
+RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.17.1/ubuntu-16-04-wake_0.17.1-1_amd64.deb && \
     dpkg -i /tmp/wake.deb && \
     rm /tmp/wake.deb
 


### PR DESCRIPTION
This is needed for getting https://github.com/sifive/block-pio-sifive/pull/48 passing, which pulls in a version of api-generator-sifive that relies on Wake 0.17 language features.

This also added a CHANGELOG file, which I am modeling off https://keepachangelog.com/en/1.0.0/, which is something I just heard about today. My plan is to change the "Unreleased" section in the CHANGELOG to "0.3.0" after this gets merged in, to demonstrate the version tagging process.

I tested this locally against a locally checked out block-pio-sifive.