### PR TITLE
Bump wake to 0.17.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Backwards Incompatible Changes
+- Bumped version of wake from 0.17.1 to 0.17.2, which contains some backwards incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.17.2 for details.
+
 ## [0.3.0]
 
 ### Backwards Incompatible Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -L -o /tmp/verilator.deb -L https://github.com/sifive/verilator/release
   rm /tmp/verilator.deb
 
 # Install Wake into /usr
-RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.17.1/ubuntu-16-04-wake_0.17.1-1_amd64.deb && \
+RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.17.2/ubuntu-16-04-wake_0.17.2-1_amd64.deb && \
     dpkg -i /tmp/wake.deb && \
     rm /tmp/wake.deb
 


### PR DESCRIPTION
Refs https://github.com/sifive/soc-testsocket-sifive/pull/20.

This makes a pretty simple change to use wake 0.17.2 in environment-blockci-sifive. I'm planning to create a 0.4.0 release from this, bumping an entire minor version number from 3 to 4 since wake 0.17.2 actually introduces a number of backwards-incompatible changes to the language.

According to what's written in the [README](https://github.com/sifive/environment-blockci-sifive/blob/0.3.0/README.md#updating-the-docker-images), tagging this repo should automatically trigger a Docker image build and an upload to Docker Hub.

I tested this by building the image locally on my laptop and confirming that block-pio-sifive's `runSim pioDUT` target still succeeds (but now with wake nagging me about using `-x`).