### PR TITLE
Create 0.4.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.4.0]
+
 ### Backwards Incompatible Changes
 - Bumped version of wake from 0.17.1 to 0.17.2, which contains some backwards incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.17.2 for details.
+
 
 ## [0.3.0]
 
 ### Backwards Incompatible Changes
 - Bumped version of wake from 0.15.1 to 0.17.1, which contains backwards incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.16.0 and https://github.com/sifive/wake/releases/tag/v0.17.0 for the major changes.
 
-[Unreleased]: https://github.com/sifive/environment-blockci-sifive/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/sifive/environment-blockci-sifive/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/sifive/environment-blockci-sifive/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/sifive/environment-blockci-sifive/compare/0.2.1...0.3.0


### PR DESCRIPTION
The only difference between this and 0.3.0 is https://github.com/sifive/environment-blockci-sifive/pull/8, which bumps the Wake version to 0.17.2.

I am following the same steps I took in https://github.com/sifive/environment-blockci-sifive/pull/7, so I think these are the steps for creating a new release.

Will merge and create the v0.4.0 tag when CI passes, which should automatically kick off a job to publish the Docker image.