### PR TITLE
Revert to supported versions of tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Backwards Incompatible Changes
 - The environment runner now only matches on specific versions of protobuf, verilator, and riscv-tools.
+- Protobuf has been downgraded from 3.7.1 to 3.5.1 to match api-firrtl-sifive.
+- The RISC-V GNU toolchain has been downgraded to SiFive's 2019.05 release to match freedom-metal.
+- Verilator has been upgraded to 4.028 to match api-generator-sifive.
 
 
 ## [0.4.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,18 @@ RUN apt-get update && apt-get install -y \
   zip
 
 # Install RISC-V Toolchain into /opt/risc*
-RUN curl -L -o /tmp/riscv-tools.tar.gz https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz && \
+RUN curl -L -o /tmp/riscv-tools.tar.gz https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.2.0-2019.05.3-x86_64-linux-ubuntu14.tar.gz && \
     tar xzf /tmp/riscv-tools.tar.gz -C /opt && \
     rm /tmp/riscv-tools.tar.gz
 
 # Install protocol buffers (protoc) into /usr/local
-RUN curl -L -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip && \
+RUN curl -L -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip && \
     cd /usr/local && \
     unzip /tmp/protoc.zip && \
     rm /tmp/protoc.zip
 
 # Install Verilator into /usr/local
-RUN curl -L -o /tmp/verilator.deb -L https://github.com/sifive/verilator/releases/download/4.016-0sifive1/verilator_4.016-0sifive1_amd64.deb && \
+RUN curl -L -o /tmp/verilator.deb -L https://github.com/sifive/verilator/releases/download/4.028-0sifive1/verilator_4.028-0sifive1_amd64.deb && \
   apt install -y /tmp/verilator.deb && \
   rm /tmp/verilator.deb
 

--- a/environment.json
+++ b/environment.json
@@ -1,19 +1,19 @@
 {
   "google": {
     "protobuf": {
-      "3.7.1": {
+      "3.5.1": {
         "PATH": "/usr/local/bin"
       }
     }
   },
   "verilator": {
-    "4.016": {
+    "4.028": {
       "PATH": "/usr/local/bin"
     }
   },
   "riscv-tools": {
-    "2019.08.0": {
-      "PATH": "/opt/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14/bin"
+    "2019.05.0": {
+      "PATH": "/opt/riscv64-unknown-elf-gcc-8.2.0-2019.05.3-x86_64-linux-ubuntu14/bin"
     }
   }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/sifive/environment-blockci-sifive/pull/5

All I've done here is change the versions of some of the tools installed in the Docker container such that they match the versions specifically requested by the Wake rules in a few of our open source repositories. Several of these involve reversions to older versions of tools.

Let me quote my CHANGELOG entry here in the PR:

> - Protobuf has been downgraded from 3.7.1 to 3.5.1 to match api-firrtl-sifive.
> - The RISC-V GNU toolchain has been downgraded to SiFive's 2019.05 release to match freedom-metal.
> - Verilator has been upgraded to 4.028 to match api-generator-sifive.

This was tested by building this Docker container locally and running block-pio-sifive on it, which seemed to pass after I made these changes.

I am planning to cut a release with these changes as 0.5.0, and then after that create an 0.6.0 with wake 0.18.1 installed.