### PR TITLE
Upgrade to Wake 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Backwards Incompatible Changes
+- Bumped version of wake from 0.17.2 to 0.18.1, which contains a number of backwards incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.18.0 and https://github.com/sifive/wake/releases/tag/v0.18.1 for more details.
+
 
 ## [0.5.0]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -L -o /tmp/verilator.deb -L https://github.com/sifive/verilator/release
   rm /tmp/verilator.deb
 
 # Install Wake into /usr
-RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.17.2/ubuntu-16-04-wake_0.17.2-1_amd64.deb && \
+RUN curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-16-04-wake_0.18.1-1_amd64.deb && \
     dpkg -i /tmp/wake.deb && \
     rm /tmp/wake.deb
 


### PR DESCRIPTION
This upgrades the version of Wake installed to 0.18.1. I tested that this container is capable of running successfully on block-pio-sifive, but there are a few changes that need to be made to api-generator-sifive, which can be done separately.