### PR TITLE
actions/wake: add github action to run wake in the environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test_wake_action:
+    runs-on: ubuntu-latest
+    name: A job to test the wake rule
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./actions/wake
+        with:
+          command: --no-workspace -x 'seq 100'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a GitHub Action which can run a Wake command within the environment-blockci-sifive Docker container. https://github.com/sifive/environment-blockci-sifive/pull/15
+
+
 ## [0.7.0]
 
 ### Backwards Incompatible Changes

--- a/actions/wake/README.md
+++ b/actions/wake/README.md
@@ -1,0 +1,29 @@
+# Wake Action
+
+This [GitHub Action](https://github.com/features/actions) will execute wake
+inside the environment-blockci-sifive docker container.  The
+environment-blockci-sifive should be included into the wit workspace so that
+build rules are aware of the available tools.  If no command is specified,
+wake simply type checks the build rules.
+
+See [action.yml](./action.yml) for a detailed list of input parameters.
+
+## Example Usage
+
+```yaml
+jobs:
+  test:
+    name: Scala compile
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Wit Init
+      uses: sifive/wit/actions/init@v0.13.2
+      with:
+        environment: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+
+    - name: Run wake scala compile
+      uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
+      with:
+        command: -x 'compileScalaModule myScalaModule | getPathResult'
+```

--- a/actions/wake/action.yml
+++ b/actions/wake/action.yml
@@ -1,0 +1,33 @@
+name: 'Wake Action'
+description: 'Invoke wake inside the environment-blockci-sifive container'
+inputs:
+  command:
+    description: |
+      The command which will be executed by wake inside the workspace.
+      By default, wake will simply type-check the build system.
+    required: false
+    default: '-x Unit'
+  workspace:
+    description: |
+      The location (relative to the build directory) of the root of the wit
+      workspace.  This should typically match wherever wit/actions/init ran.
+    required: false
+    default: .
+  version:
+    description: |
+      The version of the environment-blockci-sifive docker image to use.  By
+      default, the same version is used as the release tag of the action.
+    required: false
+    default: 0.7.0
+
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        set -xeuo pipefail
+        docker run --rm \
+          --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
+          --volume="$GITHUB_WORKSPACE/${{ inputs.workspace }}:/mnt/workspace" --workdir="/mnt/workspace" \
+          sifive/environment-blockci:${{ inputs.version }} \
+          wake ${{ inputs.command }}
+      shell: bash


### PR DESCRIPTION
This PR:
- defines a github action to run wake in the envinronment-blockci-sifive docker image
- adds documentation for said action
- test that action as part of CI for this repository

Example:
```yaml
 jobs:
   test:
     name: Scala compile
     runs-on: ubuntu-latest

     steps:
     - name: Wit Init
       uses: sifive/wit/actions/init@v0.13.2
       with:
         additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0

     - name: Run wake scala compile
       uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
       with:
         command: -x 'compileScalaModule myScalaModule | getPathResult'
 ```