### PR TITLE
Update 0.7.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Added a GitHub Action which can run a Wake command within the environment-blockci-sifive Docker container. https://github.com/sifive/environment-blockci-sifive/pull/15
-
 
 ## [0.7.0]
 
 ### Backwards Incompatible Changes
 - Bumped version of wake from 0.18.1 to 0.19.0, which contains minor, but possibly backwards-incompatible changes to the language. See https://github.com/sifive/wake/releases/tag/v0.19.0 for more details.
+
+### Added
+- Added a GitHub Action which can run a Wake command within the environment-blockci-sifive Docker container. https://github.com/sifive/environment-blockci-sifive/pull/15
 
 
 ## [0.6.0]


### PR DESCRIPTION
Includes https://github.com/sifive/environment-blockci-sifive/pull/15, which is backwards compatible, ~~so I bumped the last version component. I am sort of making up a sem-ver convention of "bump the middle number for backwards-incompatible changes, bump the last number for backwards-compatible changes", but maybe we should just call this library at 1.0.0 at some point so that we can follow real semver~~ so I will just retag this as 0.7.0.