### PR TITLE
Install nodejs 10.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Installed NodeJS 10.15.0. Note: Although this also removed the Ubuntu 16.04-provided NodeJS v4.2.6, this is not being considered a backwards-incompatible change because that version of NodeJS is so old that it's unlikely that any Wake rules ever used it.
+
 
 ## [0.7.0]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y \
   libsqlite3-dev \
   libtool-bin \
   makedev \
-  nodejs \
   openjdk-8-jdk \
   pkg-config \
   python \
@@ -57,3 +56,10 @@ RUN add-apt-repository -y ppa:brightbox/ruby-ng && \
   apt-get update && \
   apt-get install -y ruby2.5 ruby2.5-dev && \
   gem2.5 install bundler -v 2.0.2
+
+# Install NodeJS
+RUN mkdir -p /opt/nodejs/ && \
+    curl -L -o /opt/nodejs/node.tar.xz https://nodejs.org/download/release/v10.15.0/node-v10.15.0-linux-x64.tar.xz && \
+    tar xf /opt/nodejs/node.tar.xz --directory /opt/nodejs && \
+    mv /opt/nodejs/node-v10.15.0-linux-x64 /opt/nodejs/10.15.0 && \
+    rm /opt/nodejs/node.tar.xz

--- a/environment.json
+++ b/environment.json
@@ -6,6 +6,13 @@
       }
     }
   },
+  "nodejs": {
+    "nodejs": {
+      "10.15.0": {
+        "PATH": "/opt/nodejs/10.15.0/bin"
+      }
+    }
+  },
   "verilator": {
     "4.028": {
       "PATH": "/usr/local/bin"


### PR DESCRIPTION
Some of our workflows require NodeJS. This installs 10.15.0, which matches the version that is hardcoded into api-languages-sifive.git.

Also, I discovered that we actually already have NodeJS installed previously, but it was the version that was provided by Ubuntu 16.04, which is v4.2.6, which is ancient in NodeJS time scales (it's been EOL for years). I'm not going to consider this to be a backwards-incompatible change since it's extremely unlikely that anything depended on it.