### PR TITLE
CHANGELOG: bump to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1]
+
 ### Added
 - Installed NodeJS 10.15.0. Note: Although this also removed the Ubuntu 16.04-provided NodeJS v4.2.6, this is not being considered a backwards-incompatible change because that version of NodeJS is so old that it's unlikely that any Wake rules ever used it.
-
+- Added a GitHub Action which can run a shell command within the environment-blockci-sifive Docker container. https://github.com/sifive/environment-blockci-sifive/pull/22
 
 ## [0.7.0]
 

--- a/actions/shell/README.md
+++ b/actions/shell/README.md
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Run a shell command
-      uses: sifive/environment-blockci-sifive/actions/shell@0.7.0
+      uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
       with:
         command: echo "Hello World"
 ```

--- a/actions/shell/action.yml
+++ b/actions/shell/action.yml
@@ -16,7 +16,7 @@ inputs:
       The version of the environment-blockci-sifive docker image to use.  By
       default, the same version is used as the release tag of the action.
     required: false
-    default: 0.7.0
+    default: 0.7.1
 
 runs:
   using: "composite"

--- a/actions/wake/README.md
+++ b/actions/wake/README.md
@@ -20,10 +20,10 @@ jobs:
     - name: Wit Init
       uses: sifive/wit/actions/init@v0.13.2
       with:
-        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.1
 
     - name: Run wake scala compile
-      uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
+      uses: sifive/environment-blockci-sifive/actions/wake@0.7.1
       with:
         command: -x 'compileScalaModule myScalaModule | getPathResult'
 ```

--- a/actions/wake/action.yml
+++ b/actions/wake/action.yml
@@ -18,7 +18,7 @@ inputs:
       The version of the environment-blockci-sifive docker image to use.  By
       default, the same version is used as the release tag of the action.
     required: false
-    default: 0.7.0
+    default: 0.7.1
 
 runs:
   using: "composite"


### PR DESCRIPTION
Presumably we need to trigger the docker image build as well.