### PR TITLE
Fix GitHub Action default versions

### DIFF
--- a/actions/shell/README.md
+++ b/actions/shell/README.md
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Run a shell command
-      uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
+      uses: sifive/environment-blockci-sifive/actions/shell@0.8.0
       with:
         command: echo "Hello World"
 ```

--- a/actions/shell/action.yml
+++ b/actions/shell/action.yml
@@ -16,7 +16,7 @@ inputs:
       The version of the environment-blockci-sifive docker image to use.  By
       default, the same version is used as the release tag of the action.
     required: false
-    default: 0.7.1
+    default: 0.8.0
 
 runs:
   using: "composite"

--- a/actions/wake/README.md
+++ b/actions/wake/README.md
@@ -20,10 +20,10 @@ jobs:
     - name: Wit Init
       uses: sifive/wit/actions/init@v0.13.2
       with:
-        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.1
+        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.8.0
 
     - name: Run wake scala compile
-      uses: sifive/environment-blockci-sifive/actions/wake@0.7.1
+      uses: sifive/environment-blockci-sifive/actions/wake@0.8.0
       with:
         command: -x 'compileScalaModule myScalaModule | getPathResult'
 ```

--- a/actions/wake/action.yml
+++ b/actions/wake/action.yml
@@ -18,7 +18,7 @@ inputs:
       The version of the environment-blockci-sifive docker image to use.  By
       default, the same version is used as the release tag of the action.
     required: false
-    default: 0.7.1
+    default: 0.8.0
 
 runs:
   using: "composite"

--- a/docs/how-to/make-a-release.md
+++ b/docs/how-to/make-a-release.md
@@ -19,16 +19,19 @@ repository that can be used as a [Wit](https://github.com/sifive/wit) package.
    collected there.
 4. Also update the CHANGELOG to create a new link at the bottom that shows the
    diffs between the previous version and the new `version`.
-5. Commit the changes and push them up to GitHub as a pull request. An example
+5. Update the GitHub actions in the `actions/` directory such that the default
+   value of the version parameter is set to `version`. Do this in both
+   `action.yml` as well as the examples in `README.md`.
+6. Commit the changes and push them up to GitHub as a pull request. An example
    release pull request is
    https://github.com/sifive/environment-blockci-sifive/pull/9.
-6. Merge the pull request to `master`.
-7. Tag the merge commit as `<version>` (e.g. `0.4.0`) and push the tag to
+7. Merge the pull request to `master`.
+8. Tag the merge commit as `<version>` (e.g. `0.4.0`) and push the tag to
    GitHub. This should trigger a Travis CI build that creates the Docker image
    and pushes it up to Docker Hub with a Docker tag that matches the Git tag.
-8. Confirm that the Travis CI build succeeds and that the Docker image is
+9. Confirm that the Travis CI build succeeds and that the Docker image is
    pushed. You can confirm the Docker image is pushed by running
    `docker pull sifive/environment-blockci:<version>`.
-9. Create a new [GitHub Release](https://github.com/sifive/environment-blockci-sifive/releases/new)
+10. Create a new [GitHub Release](https://github.com/sifive/environment-blockci-sifive/releases/new)
    where the title is just the version string (with a `v` prefix) and the body
    is just the contents from the CHANGELOG.


### PR DESCRIPTION
@nategraff-sifive pointed out to me that I forgot to bump the default version of `environment-blockci-sifive` referenced in the GitHub Actions definitions in this repo when I made the 0.8.0 release. This PR fixes that and also updates the documentation on making a release to specifically mention updating the Actions.

Since I don't think anything else is relying on 0.8.0 yet, I'd like to retag the repo with 0.8.0 after merging these changes in. Do either of you see any issue with that? Alternatively, I can cut a separate 0.8.1 release that has all the fixes.